### PR TITLE
Retheme UI to monochrome e-ink aesthetic

### DIFF
--- a/supernote/server/static/index.html
+++ b/supernote/server/static/index.html
@@ -20,21 +20,21 @@
     </script>
 </head>
 
-<body class="bg-slate-50 text-slate-900 antialiased min-h-screen">
+<body class="bg-white text-black antialiased min-h-screen">
     <div id="app" class="flex flex-col min-h-screen" v-cloak>
-        <header class="sticky top-0 z-50 bg-white/70 backdrop-blur-md border-b border-slate-200">
+        <header class="sticky top-0 z-50 bg-black border-b border-gray-800">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="flex justify-between items-center h-16">
                     <div class="flex items-center gap-3">
                         <div
-                            class="w-8 h-8 bg-indigo-600 rounded-lg flex items-center justify-center text-white font-bold shadow-lg shadow-indigo-200">
+                            class="w-8 h-8 bg-white rounded flex items-center justify-center text-black font-bold">
                             S</div>
-                        <h1 class="text-xl font-semibold tracking-tight">Supernote <span
-                                class="text-indigo-600">Lite</span></h1>
+                        <h1 class="text-xl font-semibold tracking-tight text-white">Supernote <span
+                                class="text-gray-400">Lite</span></h1>
                     </div>
                     <div v-if="isLoggedIn" class="flex items-center gap-4">
                         <button @click="showSystemPanel = true"
-                            class="text-slate-500 hover:text-slate-700 transition-colors" title="System Status">
+                            class="text-gray-400 hover:text-white transition-colors" title="System Status">
                             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                     d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z">
@@ -42,7 +42,7 @@
                             </svg>
                         </button>
                         <button @click="handleLogout"
-                            class="text-sm font-medium text-slate-500 hover:text-slate-800 transition-colors">
+                            class="text-sm font-medium text-gray-400 hover:text-white transition-colors">
                             Sign Out
                         </button>
                     </div>
@@ -54,10 +54,10 @@
             <template v-if="isLoggedIn">
                 <!-- Breadcrumbs -->
                 <nav
-                    class="flex mb-8 text-sm font-medium text-slate-500 items-center overflow-x-auto whitespace-nowrap pb-2">
+                    class="flex mb-8 text-sm font-medium text-gray-500 items-center overflow-x-auto whitespace-nowrap pb-2">
                     <div v-for="(crumb, index) in breadcrumbs" :key="crumb.id" class="flex items-center">
                         <button @click="navigateTo(index)"
-                            :class="index === breadcrumbs.length - 1 ? 'text-slate-900 font-bold' : 'hover:text-indigo-600 transition-colors'"
+                            :class="index === breadcrumbs.length - 1 ? 'text-black font-bold' : 'hover:text-black transition-colors'"
                             class="flex items-center">
                             <svg v-if="index === 0" class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
                                 <path
@@ -66,14 +66,14 @@
                             </svg>
                             {{ crumb.name }}
                         </button>
-                        <span v-if="index < breadcrumbs.length - 1" class="mx-2 text-slate-300">/</span>
+                        <span v-if="index < breadcrumbs.length - 1" class="mx-2 text-gray-300">/</span>
                     </div>
                 </nav>
                 <!-- Actions Bar -->
                 <div class="flex flex-wrap items-center justify-between gap-4 mb-8">
                     <div class="flex items-center gap-2">
                         <button @click="triggerUpload"
-                            class="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-xl font-medium transition-all shadow-lg shadow-indigo-100">
+                            class="flex items-center gap-2 bg-black hover:bg-gray-800 text-white px-4 py-2 rounded font-medium transition-all">
                             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                     d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"></path>
@@ -81,8 +81,8 @@
                             Upload
                         </button>
                         <button @click="showNewFolderModal = true"
-                            class="flex items-center gap-2 bg-white hover:bg-slate-50 text-slate-700 border border-slate-200 px-4 py-2 rounded-xl font-medium transition-all">
-                            <svg class="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            class="flex items-center gap-2 bg-white hover:bg-gray-100 text-black border border-gray-300 px-4 py-2 rounded font-medium transition-all">
+                            <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                     d="M12 4v16m8-8H4"></path>
                             </svg>
@@ -91,17 +91,17 @@
                     </div>
 
                     <div v-if="selectedIds.length > 0" class="flex items-center gap-2 animate-in slide-in-from-right">
-                        <span class="text-sm text-slate-500 font-medium mr-2">{{ selectedIds.length }} selected</span>
+                        <span class="text-sm text-gray-500 font-medium mr-2">{{ selectedIds.length }} selected</span>
                         <button @click="handleMoveSelected"
-                            class="text-sm bg-white border border-slate-200 hover:bg-slate-50 text-slate-700 px-3 py-1.5 rounded-lg transition-colors">
+                            class="text-sm bg-white border border-gray-300 hover:bg-gray-100 text-black px-3 py-1.5 rounded transition-colors">
                             Move
                         </button>
                         <button @click="handleDeleteSelected"
-                            class="text-sm bg-rose-50 border border-rose-100 hover:bg-rose-100 text-rose-600 px-3 py-1.5 rounded-lg transition-colors">
+                            class="text-sm bg-black border border-black hover:bg-gray-800 text-white px-3 py-1.5 rounded transition-colors">
                             Delete
                         </button>
                         <button @click="selectedIds = []"
-                            class="text-sm text-slate-400 hover:text-slate-600 underline px-2">
+                            class="text-sm text-gray-400 hover:text-black underline px-2">
                             Clear
                         </button>
                     </div>
@@ -112,18 +112,18 @@
 
                 <!-- New Folder Modal -->
                 <div v-if="showNewFolderModal"
-                    class="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-slate-900/40 backdrop-blur-sm"
+                    class="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/50"
                     @click.self="showNewFolderModal = false">
-                    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md p-6 animate-in zoom-in-95">
-                        <h3 class="text-lg font-bold text-slate-900 mb-4">Create New Folder</h3>
+                    <div class="bg-white rounded-lg border border-gray-300 shadow-xl w-full max-w-md p-6">
+                        <h3 class="text-lg font-bold text-black mb-4">Create New Folder</h3>
                         <input v-model="newFolderName" type="text" placeholder="Folder name"
-                            class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none transition-all mb-6"
+                            class="w-full px-4 py-3 bg-white border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-black outline-none transition-all mb-6"
                             @keyup.enter="handleCreateFolder">
                         <div class="flex justify-end gap-3">
                             <button @click="showNewFolderModal = false"
-                                class="px-4 py-2 text-slate-500 hover:text-slate-700 font-medium">Cancel</button>
+                                class="px-4 py-2 text-gray-500 hover:text-black font-medium">Cancel</button>
                             <button @click="handleCreateFolder" :disabled="!newFolderName"
-                                class="px-6 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white rounded-xl font-bold shadow-lg shadow-indigo-200 transition-all">
+                                class="px-6 py-2 bg-black hover:bg-gray-800 disabled:opacity-50 text-white rounded font-medium transition-all">
                                 Create
                             </button>
                         </div>
@@ -131,16 +131,16 @@
                 </div>
 
                 <!-- Error State -->
-                <div v-if="error" class="bg-red-50 text-red-600 p-4 rounded-xl mb-6">
+                <div v-if="error" class="bg-gray-100 text-black border border-gray-300 p-4 rounded mb-6">
                     {{ error }}
-                    <div v-if="error === 'Unauthorized'" class="mt-2 text-sm">
+                    <div v-if="error === 'Unauthorized'" class="mt-2 text-sm text-gray-600">
                         Please log in via the CLI or check your token.
                     </div>
                 </div>
 
                 <!-- Loading State -->
                 <div v-if="isLoading" class="flex justify-center py-20">
-                    <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
+                    <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-black"></div>
                 </div>
 
                 <!-- Grid View -->

--- a/supernote/server/static/js/components/FileCard.js
+++ b/supernote/server/static/js/components/FileCard.js
@@ -10,43 +10,43 @@ export default {
         }
     },
     template: `
-    <div class="group file-card bg-white rounded-3xl border border-slate-200 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all cursor-pointer overflow-hidden flex flex-col relative" :class="{'ring-2 ring-indigo-500 bg-indigo-50/30': isSelected}">
+    <div class="group file-card bg-white rounded-lg border border-gray-300 transition-all cursor-pointer overflow-hidden flex flex-col relative" :class="{'ring-2 ring-black bg-gray-100': isSelected}">
         <!-- Selection Checkbox -->
         <div class="absolute top-4 left-4 z-10 opacity-0 group-hover:opacity-100 transition-opacity" :class="{'opacity-100': isSelected}">
-            <input type="checkbox" :checked="isSelected" @change.stop="$emit('select', file.id)" class="w-5 h-5 rounded-md border-slate-300 text-indigo-600 focus:ring-indigo-500 cursor-pointer">
+            <input type="checkbox" :checked="isSelected" @change.stop="$emit('select', file.id)" class="w-5 h-5 rounded border-gray-400 text-black focus:ring-black cursor-pointer">
         </div>
 
-        <div class="aspect-[4/3] bg-slate-100 flex items-center justify-center p-8 relative transition-all bg-[url('https://www.transparenttextures.com/patterns/notebook.png')]" @click.stop="$emit('open', file)">
-            <div v-if="file.extension === 'note'" class="p-4 bg-white/80 backdrop-blur rounded-2xl shadow-lg border border-white/50">
-                <svg class="w-12 h-12 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
+        <div class="aspect-[4/3] bg-gray-100 flex items-center justify-center p-8 relative" @click.stop="$emit('open', file)">
+            <div v-if="file.extension === 'note'" class="p-4 bg-white rounded border border-gray-200">
+                <svg class="w-12 h-12 text-black" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
             </div>
-            <div v-else-if="file.isDirectory" class="p-4 bg-amber-50 text-amber-500 rounded-2xl shadow-md border border-white/50">
+            <div v-else-if="file.isDirectory" class="p-4 bg-gray-200 text-gray-600 rounded border border-gray-300">
                  <svg class="w-10 h-10" fill="currentColor" viewBox="0 0 20 20"><path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"></path></svg>
             </div>
-            <div v-else class="p-4 bg-white/80 backdrop-blur rounded-2xl shadow-lg border border-white/50">
-                <svg class="w-12 h-12 text-rose-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path></svg>
+            <div v-else class="p-4 bg-white rounded border border-gray-200">
+                <svg class="w-12 h-12 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path></svg>
             </div>
 
             <!-- Processing Overlay -->
             <div v-if="processingStatus && processingStatus !== 'COMPLETED' && processingStatus !== 'NONE'"
-                class="absolute inset-0 bg-white/60 backdrop-blur-[2px] flex items-center justify-center z-10">
+                class="absolute inset-0 bg-white/80 flex items-center justify-center z-10">
                 <div class="flex flex-col items-center gap-2">
-                    <svg class="w-8 h-8 text-indigo-600 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg class="w-8 h-8 text-black animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>
-                    <span class="text-[10px] font-bold text-indigo-700 uppercase tracking-widest">{{ processingStatus }}</span>
+                    <span class="text-[10px] font-bold text-black uppercase tracking-widest">{{ processingStatus }}</span>
                 </div>
             </div>
         </div>
         <div class="p-5 flex justify-between items-start gap-2">
             <div class="min-w-0" @click.stop="$emit('open', file)">
-                <h3 class="font-bold text-slate-800 truncate" :title="file.name">{{ file.name }}</h3>
-                <p class="text-xs text-slate-400 mt-1 uppercase tracking-wider font-semibold">
+                <h3 class="font-bold text-black truncate" :title="file.name">{{ file.name }}</h3>
+                <p class="text-xs text-gray-500 mt-1 uppercase tracking-wider font-semibold">
                     {{ file.isDirectory ? 'Folder' : file.extension }} · {{ formatSize(file.size) }}
                 </p>
             </div>
-            <button @click.stop="$emit('rename', file)" class="p-2 text-slate-400 hover:text-indigo-600 transition-colors opacity-0 group-hover:opacity-100">
+            <button @click.stop="$emit('rename', file)" class="p-2 text-gray-400 hover:text-black transition-colors opacity-0 group-hover:opacity-100">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"></path></svg>
             </button>
         </div>

--- a/supernote/server/static/js/components/FileViewer.js
+++ b/supernote/server/static/js/components/FileViewer.js
@@ -60,27 +60,27 @@ export default {
         };
     },
     template: `
-    <div class="bg-gray-100 h-full flex flex-col overflow-hidden relative">
+    <div class="bg-gray-50 h-full flex flex-col overflow-hidden relative">
         <!-- Header (Fixed) -->
-        <div class="flex-none bg-white p-4 shadow-sm z-10 flex items-center justify-between px-8">
+        <div class="flex-none bg-white p-4 border-b border-gray-200 z-10 flex items-center justify-between px-8">
             <div class="flex items-center gap-3">
-                <div class="bg-indigo-100 p-2 rounded-lg text-indigo-600">
+                <div class="bg-gray-100 p-2 rounded border border-gray-200 text-black">
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
                 </div>
                 <div>
-                    <h2 class="text-lg font-bold text-slate-800">{{ file.name }}</h2>
-                    <p class="text-xs text-slate-500">{{ pages.length }} Pages</p>
+                    <h2 class="text-lg font-bold text-black">{{ file.name }}</h2>
+                    <p class="text-xs text-gray-500">{{ pages.length }} Pages</p>
                 </div>
             </div>
             <div class="flex items-center gap-2">
                 <button @click="showDetails = !showDetails"
-                    :class="{'bg-indigo-50 text-indigo-600 border-indigo-200': showDetails, 'text-slate-600 hover:bg-slate-50 border-slate-200': !showDetails}"
-                    class="px-4 py-2 text-sm font-medium rounded-lg transition-colors border flex items-center gap-2">
+                    :class="{'bg-black text-white border-black': showDetails, 'text-gray-600 hover:bg-gray-50 border-gray-300': !showDetails}"
+                    class="px-4 py-2 text-sm font-medium rounded transition-colors border flex items-center gap-2">
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
                     Insights
                 </button>
                 <button @click="$emit('close')"
-                    class="px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50 rounded-lg transition-colors border border-slate-200">
+                    class="px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 rounded transition-colors border border-gray-300">
                     Close
                 </button>
             </div>
@@ -92,24 +92,24 @@ export default {
             <div class="flex-1 overflow-y-auto p-4 sm:p-8">
                 <div class="max-w-4xl mx-auto">
                     <!-- Error State -->
-                    <div v-if="error" class="bg-white p-12 rounded-xl shadow-sm text-center">
-                        <div class="text-red-500 mb-2">
+                    <div v-if="error" class="bg-white p-12 rounded border border-gray-200 text-center">
+                        <div class="text-gray-400 mb-2">
                             <svg class="w-12 h-12 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                         </div>
-                        <h3 class="text-lg font-medium text-slate-900">Unable to load preview</h3>
-                        <p class="text-slate-500 mt-1">{{ error }}</p>
+                        <h3 class="text-lg font-medium text-black">Unable to load preview</h3>
+                        <p class="text-gray-500 mt-1">{{ error }}</p>
                     </div>
 
                     <!-- Loading State -->
-                    <div v-if="isLoading" class="flex flex-col items-center justify-center p-20 bg-white rounded-xl shadow-sm">
-                        <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-indigo-600 mb-4"></div>
-                        <p class="text-slate-500 animate-pulse">Converting note...</p>
+                    <div v-if="isLoading" class="flex flex-col items-center justify-center p-20 bg-white rounded border border-gray-200">
+                        <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-black mb-4"></div>
+                        <p class="text-gray-500">Converting note...</p>
                     </div>
 
                     <!-- Pages List -->
                     <div v-if="!isLoading && !error && pages.length > 0" class="space-y-6">
-                        <div v-for="page in pages" :key="page.pageNo" class="bg-white rounded-xl shadow-md overflow-hidden transition-transform hover:scale-[1.005] duration-300">
-                            <div class="border-b border-slate-100 p-3 bg-slate-50 flex justify-between items-center text-xs text-slate-400 font-mono">
+                        <div v-for="page in pages" :key="page.pageNo" class="bg-white rounded border border-gray-200 overflow-hidden">
+                            <div class="border-b border-gray-200 p-3 bg-gray-50 flex justify-between items-center text-xs text-gray-400 font-mono">
                                 <span>Page {{ page.pageNo }}</span>
                             </div>
                             <img :src="page.url" loading="lazy" class="w-full h-auto block" alt="Note Page" />
@@ -127,7 +127,7 @@ export default {
                 leave-from-class="translate-x-0"
                 leave-to-class="translate-x-full"
             >
-                <div v-if="showDetails" class="w-96 border-l border-slate-200 shadow-xl z-20 absolute right-0 top-0 bottom-0 bg-white md:relative">
+                <div v-if="showDetails" class="w-96 border-l border-gray-200 z-20 absolute right-0 top-0 bottom-0 bg-white md:relative">
                     <summary-panel :file-id="file.id" @close="showDetails = false"></summary-panel>
                 </div>
             </transition>

--- a/supernote/server/static/js/components/LoginCard.js
+++ b/supernote/server/static/js/components/LoginCard.js
@@ -25,38 +25,38 @@ export default {
         };
     },
     template: `
-    <div class="max-w-md mx-auto bg-white rounded-3xl border border-slate-200 shadow-xl overflow-hidden mt-20">
+    <div class="max-w-md mx-auto bg-white rounded-lg border border-gray-300 shadow-lg overflow-hidden mt-20">
         <div class="p-8 sm:p-12">
             <div class="text-center mb-8">
-                <div class="w-16 h-16 bg-indigo-600 rounded-2xl flex items-center justify-center text-white text-2xl font-bold shadow-lg shadow-indigo-200 mx-auto mb-4">S</div>
-                <h2 class="text-2xl font-bold text-slate-900">Welcome Back</h2>
-                <p class="text-slate-500 mt-2">Sign in to access your Supernote cloud</p>
+                <div class="w-16 h-16 bg-black rounded-lg flex items-center justify-center text-white text-2xl font-bold mx-auto mb-4">S</div>
+                <h2 class="text-2xl font-bold text-black">Welcome Back</h2>
+                <p class="text-gray-500 mt-2">Sign in to access your Supernote Cloud</p>
             </div>
 
             <form @submit.prevent="handleSubmit" class="space-y-6">
                 <div>
-                    <label class="block text-sm font-medium text-slate-700 mb-2">Email Address</label>
+                    <label class="block text-sm font-medium text-black mb-2">Email Address</label>
                     <input type="email" v-model="email" required
-                        class="w-full px-4 py-3 rounded-xl border border-slate-200 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none transition-all"
+                        class="w-full px-4 py-3 rounded border border-gray-300 focus:border-black focus:ring-2 focus:ring-gray-200 outline-none transition-all"
                         placeholder="you@example.com">
                 </div>
 
                 <div>
-                    <label class="block text-sm font-medium text-slate-700 mb-2">Password</label>
+                    <label class="block text-sm font-medium text-black mb-2">Password</label>
                     <input type="password" v-model="password" required
-                        class="w-full px-4 py-3 rounded-xl border border-slate-200 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none transition-all"
+                        class="w-full px-4 py-3 rounded border border-gray-300 focus:border-black focus:ring-2 focus:ring-gray-200 outline-none transition-all"
                         placeholder="••••••••">
                 </div>
 
                 <button type="submit"
                     :disabled="isLoading"
-                    class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-3 px-4 rounded-xl shadow-lg shadow-indigo-200 transition-all transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed flex justify-center items-center">
+                    class="w-full bg-black hover:bg-gray-800 text-white font-medium py-3 px-4 rounded transition-all disabled:opacity-50 disabled:cursor-not-allowed flex justify-center items-center">
                     <span v-if="isLoading" class="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></span>
                     {{ isLoading ? 'Signing in...' : 'Sign In' }}
                 </button>
             </form>
         </div>
-        <div class="bg-slate-50 p-4 text-center text-xs text-slate-400 border-t border-slate-100">
+        <div class="bg-gray-50 p-4 text-center text-xs text-gray-400 border-t border-gray-200">
             Supernote Private Cloud Server
         </div>
     </div>

--- a/supernote/server/static/js/components/MoveModal.js
+++ b/supernote/server/static/js/components/MoveModal.js
@@ -4,35 +4,35 @@ export default {
     name: 'MoveModal',
     props: ['itemIds'],
     template: `
-        <div class="fixed inset-0 z-[110] flex items-center justify-center p-4 bg-slate-900/40 backdrop-blur-sm" @click.self="$emit('close')">
-            <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md flex flex-col max-h-[80vh] animate-in zoom-in-95">
-                <div class="p-6 border-b border-slate-100 flex items-center justify-between">
-                    <h3 class="text-lg font-bold text-slate-900">Move {{ itemIds.length }} items to...</h3>
-                    <button @click="$emit('close')" class="text-slate-400 hover:text-slate-600">
+        <div class="fixed inset-0 z-[110] flex items-center justify-center p-4 bg-black/50" @click.self="$emit('close')">
+            <div class="bg-white rounded-lg border border-gray-300 shadow-xl w-full max-w-md flex flex-col max-h-[80vh]">
+                <div class="p-6 border-b border-gray-200 flex items-center justify-between">
+                    <h3 class="text-lg font-bold text-black">Move {{ itemIds.length }} items to...</h3>
+                    <button @click="$emit('close')" class="text-gray-400 hover:text-black">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
 
                 <div class="flex-1 overflow-y-auto p-2">
-                    <div @click="selectTarget('0')" class="flex items-center gap-3 p-3 rounded-xl hover:bg-slate-50 cursor-pointer transition-colors" :class="{'bg-indigo-50 border border-indigo-100': targetDirId === '0'}">
-                        <div class="w-10 h-10 bg-indigo-100 text-indigo-600 rounded-lg flex items-center justify-center">
+                    <div @click="selectTarget('0')" class="flex items-center gap-3 p-3 rounded hover:bg-slate-50 cursor-pointer transition-colors" :class="{'bg-slate-100 border border-slate-300': targetDirId === '0'}">
+                        <div class="w-10 h-10 bg-slate-200 text-slate-700 rounded flex items-center justify-center">
                             <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path></svg>
                         </div>
-                        <span class="font-medium text-slate-700">Cloud Root</span>
+                        <span class="font-medium text-black">Cloud Root</span>
                     </div>
 
-                    <div v-for="folder in folders" :key="folder.id" @click="selectTarget(folder.id)" class="flex items-center gap-3 p-3 rounded-xl hover:bg-slate-50 cursor-pointer transition-colors" :class="{'bg-indigo-50 border border-indigo-100': targetDirId === folder.id}">
+                    <div v-for="folder in folders" :key="folder.id" @click="selectTarget(folder.id)" class="flex items-center gap-3 p-3 rounded hover:bg-slate-50 cursor-pointer transition-colors" :class="{'bg-slate-100 border border-slate-300': targetDirId === folder.id}">
                         <div class="w-10 h-10 bg-amber-100 text-amber-600 rounded-lg flex items-center justify-center">
                             <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"></path></svg>
                         </div>
-                        <span class="font-medium text-slate-700">{{ folder.name }}</span>
+                        <span class="font-medium text-black">{{ folder.name }}</span>
                     </div>
                 </div>
 
-                <div class="p-6 border-t border-slate-100 flex justify-end gap-3">
-                    <button @click="$emit('close')" class="px-4 py-2 text-slate-500 hover:text-slate-700 font-medium">Cancel</button>
+                <div class="p-6 border-t border-gray-200 flex justify-end gap-3">
+                    <button @click="$emit('close')" class="px-4 py-2 text-gray-500 hover:text-black font-medium">Cancel</button>
                     <button @click="confirmMove" :disabled="!targetDirId"
-                        class="px-6 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white rounded-xl font-bold shadow-lg shadow-indigo-200 transition-all">
+                        class="px-6 py-2 bg-black hover:bg-gray-800 disabled:opacity-50 text-white rounded font-medium transition-all">
                         Move Here
                     </button>
                 </div>

--- a/supernote/server/static/js/components/RenameModal.js
+++ b/supernote/server/static/js/components/RenameModal.js
@@ -2,16 +2,16 @@ export default {
     name: 'RenameModal',
     props: ['item'],
     template: `
-        <div class="fixed inset-0 z-[110] flex items-center justify-center p-4 bg-slate-900/40 backdrop-blur-sm" @click.self="$emit('close')">
-            <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md p-6 animate-in zoom-in-95">
-                <h3 class="text-lg font-bold text-slate-900 mb-4">Rename {{ item.isDirectory ? 'Folder' : 'File' }}</h3>
+        <div class="fixed inset-0 z-[110] flex items-center justify-center p-4 bg-black/50" @click.self="$emit('close')">
+            <div class="bg-white rounded-lg border border-gray-300 shadow-xl w-full max-w-md p-6">
+                <h3 class="text-lg font-bold text-black mb-4">Rename {{ item.isDirectory ? 'Folder' : 'File' }}</h3>
                 <input v-model="newName" type="text" placeholder="New name"
-                    class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none transition-all mb-6"
+                    class="w-full px-4 py-3 bg-white border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-black outline-none transition-all mb-6"
                     @keyup.enter="handleRename" ref="nameInput">
                 <div class="flex justify-end gap-3">
-                    <button @click="$emit('close')" class="px-4 py-2 text-slate-500 hover:text-slate-700 font-medium">Cancel</button>
+                    <button @click="$emit('close')" class="px-4 py-2 text-gray-500 hover:text-black font-medium">Cancel</button>
                     <button @click="handleRename" :disabled="!newName || newName === item.name"
-                        class="px-6 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white rounded-xl font-bold shadow-lg shadow-indigo-200 transition-all">
+                        class="px-6 py-2 bg-black hover:bg-gray-800 disabled:opacity-50 text-white rounded font-medium transition-all">
                         Rename
                     </button>
                 </div>

--- a/supernote/server/static/js/components/SummaryPanel.js
+++ b/supernote/server/static/js/components/SummaryPanel.js
@@ -54,14 +54,14 @@ export default {
         };
     },
     template: `
-    <div class="h-full flex flex-col bg-white border-l border-slate-200 shadow-xl w-full md:w-96 transition-all duration-300">
+    <div class="h-full flex flex-col bg-white border-l border-gray-200 w-full md:w-96">
         <!-- Header -->
-        <div class="p-4 border-b border-slate-100 bg-slate-50 flex items-center justify-between">
-            <h3 class="font-semibold text-slate-800 flex items-center gap-2">
-                <svg class="w-5 h-5 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+        <div class="p-4 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+            <h3 class="font-semibold text-black flex items-center gap-2">
+                <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
                 AI Insights
             </h3>
-            <button @click="$emit('close')" class="text-slate-400 hover:text-slate-600">
+            <button @click="$emit('close')" class="text-gray-400 hover:text-black">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
             </button>
         </div>
@@ -70,30 +70,30 @@ export default {
         <div class="flex-1 overflow-y-auto p-4 space-y-4">
             <!-- Loading -->
             <div v-if="isLoading" class="flex flex-col items-center justify-center py-12">
-                <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 mb-3"></div>
-                <p class="text-sm text-slate-500">Thinking...</p>
+                <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-black mb-3"></div>
+                <p class="text-sm text-gray-500">Thinking...</p>
             </div>
 
             <!-- Error -->
-            <div v-if="error" class="bg-red-50 text-red-600 p-4 rounded-lg text-sm">
+            <div v-if="error" class="bg-gray-100 text-black border border-gray-300 p-4 rounded text-sm">
                 {{ error }}
             </div>
 
             <!-- Empty State -->
             <div v-if="!isLoading && !error && summaries.length === 0" class="text-center py-12">
-                <p class="text-slate-400 mb-2">No insights yet.</p>
-                <p class="text-xs text-slate-400">Summaries and transcripts will appear here once processed.</p>
+                <p class="text-gray-400 mb-2">No insights yet.</p>
+                <p class="text-xs text-gray-400">Summaries and transcripts will appear here once processed.</p>
             </div>
 
             <!-- List -->
-            <div v-for="item in summaries" :key="item.id" class="bg-slate-50 rounded-lg p-4 border border-slate-100">
+            <div v-for="item in summaries" :key="item.id" class="bg-gray-50 rounded p-4 border border-gray-200">
                 <div class="flex items-center justify-between mb-2">
-                    <span class="text-xs font-semibold px-2 py-1 rounded bg-white text-slate-600 border border-slate-200 capitalize">
+                    <span class="text-xs font-semibold px-2 py-1 rounded bg-white text-gray-600 border border-gray-200 capitalize">
                         {{ item.dataSource || 'Unknown' }}
                     </span>
-                    <span class="text-xs text-slate-400">{{ formatDate(item.creationTime) }}</span>
+                    <span class="text-xs text-gray-400">{{ formatDate(item.creationTime) }}</span>
                 </div>
-                <div class="prose prose-sm prose-slate max-w-none text-slate-600" v-html="formatContent(item.content)"></div>
+                <div class="prose prose-sm max-w-none text-gray-700" v-html="formatContent(item.content)"></div>
             </div>
         </div>
     </div>

--- a/supernote/server/static/js/components/SystemPanel.js
+++ b/supernote/server/static/js/components/SystemPanel.js
@@ -3,12 +3,12 @@ import { fetchSystemTasks, fetchCapacity } from '../api/client.js';
 export default {
     name: 'SystemPanel',
     template: `
-        <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" @click.self="$emit('close')">
-            <div class="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col">
+        <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50" @click.self="$emit('close')">
+            <div class="bg-white rounded-lg border border-gray-300 shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col">
                 <!-- Header -->
-                <div class="flex items-center justify-between p-4 border-b">
-                    <h2 class="text-xl font-bold text-gray-800">System Status</h2>
-                    <button @click="$emit('close')" class="text-gray-500 hover:text-gray-700">
+                <div class="flex items-center justify-between p-4 border-b border-gray-200">
+                    <h2 class="text-xl font-bold text-black">System Status</h2>
+                    <button @click="$emit('close')" class="text-gray-400 hover:text-black">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                         </svg>
@@ -18,15 +18,15 @@ export default {
                 <!-- Content -->
                 <div class="flex-1 overflow-y-auto p-4 space-y-6">
                     <!-- Storage Quota -->
-                    <div class="bg-gray-50 p-4 rounded-lg">
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Storage Usage</h3>
+                    <div class="bg-gray-50 p-4 rounded border border-gray-200">
+                        <h3 class="text-lg font-medium text-black mb-2">Storage Usage</h3>
                         <div v-if="capacity" class="space-y-2">
                             <div class="flex justify-between text-sm text-gray-600">
                                 <span>{{ formatSize(capacity.usedCapacity) }} used</span>
                                 <span>{{ formatSize(capacity.totalCapacity) }} total</span>
                             </div>
                             <div class="w-full bg-gray-200 rounded-full h-2.5">
-                                <div class="bg-primary-600 h-2.5 rounded-full transition-all duration-500" :style="{ width: usagePercent + '%' }"></div>
+                                <div class="bg-black h-2.5 rounded-full transition-all duration-500" :style="{ width: usagePercent + '%' }"></div>
                             </div>
                         </div>
                         <div v-else class="animate-pulse bg-gray-200 h-10 rounded"></div>
@@ -34,16 +34,16 @@ export default {
 
                     <!-- Tasks -->
                     <div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-4">Processing Queue</h3>
+                        <h3 class="text-lg font-medium text-black mb-4">Processing Queue</h3>
                         <div v-if="loading" class="flex justify-center p-8">
-                            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+                            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-black"></div>
                         </div>
 
-                        <div v-else-if="error" class="p-4 bg-red-50 text-red-700 rounded-lg">
+                        <div v-else-if="error" class="p-4 bg-gray-100 text-black border border-gray-300 rounded">
                             {{ error }}
                         </div>
 
-                        <div v-else class="overflow-x-auto border rounded-lg">
+                        <div v-else class="overflow-x-auto border border-gray-200 rounded">
                             <table class="min-w-full divide-y divide-gray-200">
                                 <thead class="bg-gray-50">
                                     <tr>
@@ -58,8 +58,8 @@ export default {
                                 </thead>
                                 <tbody class="bg-white divide-y divide-gray-200">
                                     <tr v-for="task in tasks" :key="task.id">
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ task.fileId }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ task.taskType }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-black">{{ task.fileId }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-black">{{ task.taskType }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ task.key }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap">
                                             <span :class="statusClass(task.status)" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full">
@@ -68,7 +68,7 @@ export default {
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ task.retryCount }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ formatDate(task.updateTime) }}</td>
-                                        <td class="px-6 py-4 text-sm text-red-600 max-w-xs truncate" :title="task.lastError">
+                                        <td class="px-6 py-4 text-sm text-gray-500 max-w-xs truncate" :title="task.lastError">
                                             {{ task.lastError }}
                                         </td>
                                     </tr>
@@ -82,11 +82,11 @@ export default {
                 </div>
 
                 <!-- Footer -->
-                <div class="p-4 border-t bg-gray-50 flex justify-end">
-                    <button @click="loadData" class="mr-2 px-4 py-2 bg-white border border-gray-300 rounded shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50">
+                <div class="p-4 border-t border-gray-200 bg-gray-50 flex justify-end">
+                    <button @click="loadData" class="mr-2 px-4 py-2 bg-white border border-gray-300 rounded text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors">
                         Refresh
                     </button>
-                    <button @click="$emit('close')" class="px-4 py-2 bg-primary-600 border border-transparent rounded shadow-sm text-sm font-medium text-white hover:bg-primary-700">
+                    <button @click="$emit('close')" class="px-4 py-2 bg-black border border-black rounded text-sm font-medium text-white hover:bg-gray-800 transition-colors">
                         Close
                     </button>
                 </div>
@@ -136,12 +136,12 @@ export default {
         },
         statusClass(status) {
             const classes = {
-                'PENDING': 'bg-yellow-100 text-yellow-800',
-                'PROCESSING': 'bg-blue-100 text-blue-800',
-                'COMPLETED': 'bg-green-100 text-green-800',
-                'FAILED': 'bg-red-100 text-red-800'
+                'PENDING': 'bg-gray-100 text-gray-700 border border-gray-300',
+                'PROCESSING': 'bg-gray-200 text-black border border-gray-400',
+                'COMPLETED': 'bg-black text-white',
+                'FAILED': 'bg-gray-800 text-white'
             };
-            return classes[status] || 'bg-gray-100 text-gray-800';
+            return classes[status] || 'bg-gray-100 text-gray-700';
         },
         formatDate(timestamp) {
             if (!timestamp) return '-';

--- a/supernote/server/static/js/main.js
+++ b/supernote/server/static/js/main.js
@@ -18,8 +18,8 @@ createApp({
         RenameModal
     },
     setup() {
-        // Auth State
-        const isLoggedIn = ref(false);
+        // Auth State — initialize synchronously to avoid flashing the login form
+        const isLoggedIn = ref(!!getToken());
         const loginError = ref(null);
         const showSystemPanel = ref(false);
 

--- a/supernote/server/static/style.css
+++ b/supernote/server/static/style.css
@@ -1,5 +1,14 @@
 [v-cloak] { display: none; }
 
+/* Override browser default blue focus rings with black */
+:focus-visible {
+    outline: 2px solid black;
+    outline-offset: 2px;
+}
+:focus:not(:focus-visible) {
+    outline: none;
+}
+
 body {
     font-family: 'Inter', sans-serif;
 }


### PR DESCRIPTION
## Summary

- Replace all color accents (teal, amber, rose, red, blue) with a strict black/white/gray palette to match the feel of an e-ink display
- Remove notebook texture background, backdrop-blur effects, and decorative shadows from file cards
- Reduce card/modal rounding to a flat, minimal style
- Override browser default blue focus ring with black via CSS
- Fix login form briefly flashing on page load by initialising `isLoggedIn` synchronously from stored token (also prevents 1Password save prompt on already-logged-in sessions)