### PR TITLE
fix: handle socket.io requests to prevent ASGI crash

### DIFF
--- a/supernote/server/routes/system.py
+++ b/supernote/server/routes/system.py
@@ -47,6 +47,15 @@ async def handle_query_server(request: web.Request) -> web.Response:
     return web.json_response(BaseResponse().to_dict())
 
 
+@routes.get("/socket.io/")
+@public_route
+async def handle_socketio(request: web.Request) -> web.Response:
+    # The device attempts a socket.io WebSocket connection for push notifications.
+    # This server does not implement socket.io; return 404 so the device can
+    # fall back gracefully instead of hitting the ASGI catch-all and crashing.
+    return web.Response(status=404, text="Not implemented")
+
+
 @routes.get("/api/csrf")
 @public_route
 async def handle_csrf(request: web.Request) -> web.Response:


### PR DESCRIPTION
## Summary

The Supernote device sends a WebSocket upgrade to `GET /socket.io/` for push notifications. This request was falling through to the ASGI catch-all resource (the MCP OAuth app), which raised a `RuntimeError` when it received an unexpected `websocket.close` message:

```
ERROR [aiohttp_asgi.resource] Unexpected ASGI message type 'websocket.close'
ERROR [supernote.server.app] Error handling request:
RuntimeError
```

Add an explicit `GET /socket.io/` route that returns `404` before the request reaches the ASGI resource, giving the device a clean response to fall back on.

## Test plan

- [x] All existing tests pass
- [ ] Trigger a sync from the Supernote device and confirm no `RuntimeError` in logs for the socket.io request