### PR TITLE
fix: invalidate summary task when note pages change

### DIFF
--- a/supernote/server/services/processor_modules/page_hashing.py
+++ b/supernote/server/services/processor_modules/page_hashing.py
@@ -127,6 +127,7 @@ class PageHashingModule(ProcessorModule):
 
             # Track which page_ids are present in the current file
             current_page_ids = set()
+            note_changed = False
 
             for i in range(total_pages):
                 page_info = metadata.pages[i]
@@ -161,6 +162,7 @@ class PageHashingModule(ProcessorModule):
                         row.content_hash = current_hash
                         row.text_content = None  # Clear OCR
                         row.embedding = None  # Clear Embedding
+                        note_changed = True
 
                         # Invalidate downstream tasks
                         # Note: Tasks are keyed by page_index usually?
@@ -193,6 +195,7 @@ class PageHashingModule(ProcessorModule):
                         embedding=None,
                     )
                     session.add(new_content)
+                    note_changed = True
 
             # 2. Handle Deletions
             # Any page_id in existing_map but NOT in current_page_ids is deleted
@@ -200,6 +203,7 @@ class PageHashingModule(ProcessorModule):
                 if pid not in current_page_ids:
                     logger.info(f"Page {pid} deleted (was at {row.page_index}).")
                     await session.delete(row)
+                    note_changed = True
 
                     # Cleanup Blobs
                     png_path = get_page_png_path(file_id, pid)
@@ -216,5 +220,15 @@ class PageHashingModule(ProcessorModule):
                         .where(SystemTaskDO.file_id == file_id)
                         .where(SystemTaskDO.key == f"page_{pid}")
                     )
+
+            # 3. Invalidate global summary task if any page changed
+            if note_changed:
+                logger.info(f"Note {file_id} changed. Invalidating summary task.")
+                await session.execute(
+                    delete(SystemTaskDO)
+                    .where(SystemTaskDO.file_id == file_id)
+                    .where(SystemTaskDO.key == "global")
+                    .where(SystemTaskDO.task_type == "SUMMARY_GENERATION")
+                )
 
             await session.commit()


### PR DESCRIPTION
## Summary
- When a note is updated (pages added, modified, or deleted), the `SUMMARY_GENERATION` global task was never invalidated
- This caused `SummaryModule.run_if_needed()` to skip re-generation since the task still showed `COMPLETED`
- OCR would re-run for changed pages, but insights/summaries would be stale

## Fix
In `PageHashingModule.process()`, track whether any page change occurred and delete the `SUMMARY_GENERATION` global `SystemTaskDO` record if so, forcing insights to regenerate on the next pipeline run.

## Test plan
- [ ] Upload a note, verify insights are generated
- [ ] Re-upload the same note with changes, verify insights are regenerated
- [ ] Re-upload an unchanged note, verify insights are NOT regenerated (no page hash changes)