### PR TITLE
fix: use display names for web API immutability checks

### DIFF
--- a/supernote/server/services/file.py
+++ b/supernote/server/services/file.py
@@ -17,6 +17,7 @@ from supernote.server.constants import (
     CATEGORY_CONTAINERS,
     IMMUTABLE_SYSTEM_DIRECTORIES,
     USER_DATA_BUCKET,
+    WEB_IMMUTABLE_NAMES,
 )
 from supernote.server.exceptions import (
     AccessDenied,
@@ -540,7 +541,7 @@ class FileService:
                         )
 
                 # Immutability check
-                if node.file_name in IMMUTABLE_SYSTEM_DIRECTORIES:
+                if node.file_name in WEB_IMMUTABLE_NAMES:
                     raise AccessDenied(
                         f"Cannot delete system directory: {node.file_name}"
                     )
@@ -578,7 +579,7 @@ class FileService:
                     raise FileNotFound(f"Source item {item_id} not found")
 
                 # Immutability check
-                if node.file_name in IMMUTABLE_SYSTEM_DIRECTORIES:
+                if node.file_name in WEB_IMMUTABLE_NAMES:
                     raise AccessDenied(
                         f"Cannot move system directory: {node.file_name}"
                     )
@@ -658,7 +659,7 @@ class FileService:
 
                 # Check immutability? Usually copy is allowed, but let's be safe.
                 # Actually device API copy_item blocks it too.
-                if node.file_name in IMMUTABLE_SYSTEM_DIRECTORIES:
+                if node.file_name in WEB_IMMUTABLE_NAMES:
                     raise AccessDenied(
                         f"Cannot copy system directory: {node.file_name}"
                     )
@@ -733,7 +734,7 @@ class FileService:
                 raise FileNotFound("Source not found")
 
             # Immutability check
-            if node.file_name in IMMUTABLE_SYSTEM_DIRECTORIES:
+            if node.file_name in WEB_IMMUTABLE_NAMES:
                 raise AccessDenied(f"Cannot rename system directory: {node.file_name}")
 
             # Check if name already exists in same directory


### PR DESCRIPTION
## Summary
- Web-facing service methods (`delete_items`, `move_items`, `copy_items`, `rename_item`) were checking `node.file_name` against `IMMUTABLE_SYSTEM_DIRECTORIES`, which contains all-caps device names (`SCREENSHOT`, `EXPORT`, `INBOX`)
- Users see display names (`Screenshot`, `Export`, `Inbox`) in the UI, so the check never matched exactly — yet the system folders were still blocked because the stored name (`SCREENSHOT`) is in the set
- Fix: web-facing methods now check against `WEB_IMMUTABLE_NAMES` (display names), so only folders whose stored name exactly matches a display name are protected
- Device-facing methods (`delete_item`, `move_item`, `copy_item`) retain `IMMUTABLE_SYSTEM_DIRECTORIES` checks unchanged

## Test plan
- [ ] Verify folders like `Screenshot`, `Export`, `Inbox` can be renamed and deleted from the web UI
- [ ] Verify `Note`, `Document`, `MyStyle` are still protected (cannot be renamed or deleted)
- [ ] Verify device sync operations are unaffected