### PR TITLE
fix: preserve original name for user folders sharing a system directory name

### DIFF
--- a/supernote/server/routes/file_web.py
+++ b/supernote/server/routes/file_web.py
@@ -298,7 +298,11 @@ async def handle_file_list_query(request: web.Request) -> web.Response:
 
         user_file_vos: list[UserFileVO] = []
         for entity in page_items:
-            display_name = SYSTEM_DIR_DISPLAY_NAMES.get(entity.name, entity.name)
+            display_name = (
+                SYSTEM_DIR_DISPLAY_NAMES.get(entity.name, entity.name)
+                if entity.parent_id == 0
+                else entity.name
+            )
             user_file_vos.append(
                 UserFileVO(
                     id=str(entity.id),

--- a/tests/server/web/test_listing.py
+++ b/tests/server/web/test_listing.py
@@ -351,6 +351,29 @@ async def test_path_query_flattening(
     assert info.id_path == f"{note_id}"
 
 
+async def test_system_dir_name_not_applied_to_user_folders(
+    web_client: WebClient,
+) -> None:
+    """Verify that system display names (e.g. 'Export') are not applied to user-created
+    folders that happen to share a name with a system directory."""
+    parent = await web_client.create_folder(parent_id=0, name="MyParent")
+    parent_id = int(parent.id)
+
+    await web_client.create_folder(parent_id=parent_id, name="EXPORT")
+    await web_client.create_folder(parent_id=parent_id, name="INBOX")
+    await web_client.create_folder(parent_id=parent_id, name="SCREENSHOT")
+
+    res = await web_client.list_query(directory_id=parent_id)
+    names = {f.file_name for f in res.user_file_vo_list}
+
+    assert "EXPORT" in names
+    assert "INBOX" in names
+    assert "SCREENSHOT" in names
+    assert "Export" not in names
+    assert "Inbox" not in names
+    assert "Screenshot" not in names
+
+
 async def test_list_query_flattening(
     web_client: WebClient,
 ) -> None:


### PR DESCRIPTION
## Summary
- `SYSTEM_DIR_DISPLAY_NAMES` was applied to all folders regardless of their location, causing user-created folders named `EXPORT`, `INBOX`, or `SCREENSHOT` inside subdirectories to incorrectly display as `Export`, `Inbox`, `Screenshot`
- Fix: only apply the display name mapping when `parent_id == 0` (root level), since system directories always live at root
- Added a regression test verifying user-created folders with system-matching names in subdirectories retain their original casing

## Test plan
- [ ] Existing tests pass (`tests/server/web/` — 40 tests)
- [ ] New test `test_system_dir_name_not_applied_to_user_folders` covers the regression
- [ ] Root-level system folders (`Export`, `Inbox`, `Screenshot`) still display with their display names