### PR TITLE
fix: use issuer_url to build login-bridge return_to URL

### DIFF
--- a/supernote/server/mcp/auth.py
+++ b/supernote/server/mcp/auth.py
@@ -301,7 +301,11 @@ def create_auth_app(
 
             # Not logged in: Redirect to web UI login page (always on main_base_url,
             # even when this login-bridge is served from the MCP server domain).
-            login_url = f"{main_base_url}/#login?return_to={quote(str(request.url))}"
+            # Use issuer_url to build return_to so the scheme matches the public URL
+            # (e.g. https://), not the internal http:// seen behind a reverse proxy.
+            query_string = str(request.url.query)
+            bridge_url = f"{issuer_url.rstrip('/')}/login-bridge?{query_string}"
+            login_url = f"{main_base_url}/#login?return_to={quote(bridge_url)}"
             return RedirectResponse(url=login_url)
 
         # Extract OAuth params from query

--- a/tests/server/mcp/test_as_discovery.py
+++ b/tests/server/mcp/test_as_discovery.py
@@ -105,3 +105,48 @@ async def test_registered_client_can_authorize(client: TestClient) -> None:
     # Should redirect to login-bridge (not 400 invalid_client)
     assert resp.status in (302, 307), f"Expected redirect, got {resp.status}"
     assert "login-bridge" in resp.headers.get("Location", "")
+
+
+async def test_login_bridge_return_to_uses_issuer_url(
+    client: TestClient, server_config: ServerConfig
+) -> None:
+    """Test that login-bridge builds return_to from issuer_url, not from request.url.
+
+    When behind a TLS-terminating reverse proxy, request.url has the internal
+    http:// scheme while the public issuer_url is https://. The return_to URL must
+    use the issuer_url base so the SPA can POST back without a mixed-content block.
+    """
+    from urllib.parse import parse_qs, unquote, urlparse
+
+    # Hit /login-bridge directly with OAuth params but no auth token.
+    # It should redirect to the main login page with a return_to parameter.
+    bridge_resp = await client.get(
+        "/login-bridge",
+        params={
+            "client_id": "test-client",
+            "redirect_uri": "https://claude.ai/api/mcp/auth_callback",
+            "state": "test-state",
+            "code_challenge": "mock-challenge",
+            "code_challenge_method": "S256",
+        },
+        allow_redirects=False,
+    )
+    assert bridge_resp.status in (302, 307), (
+        f"Expected redirect from login-bridge, got {bridge_resp.status}"
+    )
+    location = bridge_resp.headers.get("Location", "")
+    assert "return_to=" in location, f"Expected return_to in Location: {location}"
+
+    # The Location is: {main_base_url}/#login?return_to=<encoded-bridge-url>
+    # Extract the encoded return_to value from the fragment.
+    parsed = urlparse(location)
+    fragment_query = parsed.fragment.split("?", 1)[-1] if "?" in parsed.fragment else ""
+    params = parse_qs(fragment_query)
+    return_to = unquote(params.get("return_to", [""])[0])
+
+    # return_to must start with the public mcp_base_url (issuer_url), not request.url
+    assert return_to.startswith(server_config.mcp_base_url), (
+        f"return_to should start with mcp_base_url '{server_config.mcp_base_url}', "
+        f"got: {return_to}"
+    )
+    assert "/login-bridge" in return_to


### PR DESCRIPTION
## Summary

- When behind a TLS-terminating reverse proxy, Starlette's `request.url` has the internal `http://` scheme while the public `mcp_base_url` is `https://`
- The `return_to` URL in the login redirect was built from `str(request.url)`, causing the SPA (served over HTTPS at `sn.ddulic.com`) to receive an `http://` `return_to` URL pointing to the MCP server
- The browser blocked the subsequent POST as **mixed active content**, breaking the OAuth callback flow
- Fixed by constructing `return_to` from `issuer_url` + the request query string, which always uses the correct public scheme