### PR TITLE
fix: show system folders with their actual names (EXPORT, INBOX, SCREENSHOT)

### DIFF
--- a/supernote/server/constants.py
+++ b/supernote/server/constants.py
@@ -19,17 +19,8 @@ CATEGORY_CONTAINERS = {"NOTE", "DOCUMENT"}
 # Forced order and specific names for web API root (when flatten=True)
 ORDERED_WEB_ROOT = ["Note", "Document"]
 
-# Maps real (device-facing) folder names to their web UI display names
-SYSTEM_DIR_DISPLAY_NAMES: dict[str, str] = {
-    "EXPORT": "Export",
-    "INBOX": "Inbox",
-    "SCREENSHOT": "Screenshot",
-}
-
-# Names that appear immutable from the web API's perspective (uses display names)
-WEB_IMMUTABLE_NAMES: frozenset[str] = frozenset(
-    SYSTEM_DIR_DISPLAY_NAMES.get(name, name) for name in IMMUTABLE_SYSTEM_DIRECTORIES
-)
+# Names that appear immutable from the web API's perspective
+WEB_IMMUTABLE_NAMES: frozenset[str] = frozenset(IMMUTABLE_SYSTEM_DIRECTORIES)
 
 # Blob Storage Buckets
 USER_DATA_BUCKET = "supernote-user-data"

--- a/supernote/server/routes/file_web.py
+++ b/supernote/server/routes/file_web.py
@@ -40,7 +40,6 @@ from supernote.models.file_web import (
 from supernote.server.constants import (
     CATEGORY_CONTAINERS,
     ORDERED_WEB_ROOT,
-    SYSTEM_DIR_DISPLAY_NAMES,
 )
 from supernote.server.exceptions import SupernoteError
 from supernote.server.services.file import (
@@ -298,16 +297,11 @@ async def handle_file_list_query(request: web.Request) -> web.Response:
 
         user_file_vos: list[UserFileVO] = []
         for entity in page_items:
-            display_name = (
-                SYSTEM_DIR_DISPLAY_NAMES.get(entity.name, entity.name)
-                if entity.parent_id == 0
-                else entity.name
-            )
             user_file_vos.append(
                 UserFileVO(
                     id=str(entity.id),
                     directory_id=str(entity.parent_id),
-                    file_name=display_name,
+                    file_name=entity.name,
                     size=entity.size,
                     md5=entity.md5,
                     inner_name=entity.storage_key,
@@ -445,10 +439,6 @@ async def handle_folder_list_query(request: web.Request) -> web.Response:
                         child.entity.parent_id = 0  # View adjustment
                         folder_details.append(child)
                 else:
-                    if detail.entity.name in SYSTEM_DIR_DISPLAY_NAMES:
-                        detail.entity.name = SYSTEM_DIR_DISPLAY_NAMES[
-                            detail.entity.name
-                        ]
                     folder_details.append(detail)
 
         folder_details.sort(key=_root_sort_key)

--- a/tests/server/web/test_device_vs_web_structure.py
+++ b/tests/server/web/test_device_vs_web_structure.py
@@ -11,9 +11,9 @@ async def test_device_vs_web_structure(
     web_res = await web_client.list_query(directory_id=0)
     web_folders = {f.file_name for f in web_res.user_file_vo_list}
 
-    # Web should see: Note, Document, MyStyle, Export, Inbox, Screenshot (display names)
+    # Web should see: Note, Document, MyStyle, EXPORT, INBOX, SCREENSHOT
     # But NOT NOTE or DOCUMENT
-    expected_web = {"Note", "Document", "MyStyle", "Export", "Inbox", "Screenshot"}
+    expected_web = {"Note", "Document", "MyStyle", "EXPORT", "INBOX", "SCREENSHOT"}
     assert expected_web.issubset(web_folders)
     assert "NOTE" not in web_folders
     assert "DOCUMENT" not in web_folders

--- a/tests/server/web/test_listing.py
+++ b/tests/server/web/test_listing.py
@@ -96,12 +96,12 @@ async def test_file_list_query_root(
         f.file_name for f in res.user_file_vo_list if f.is_folder == BooleanEnum.YES
     ] == [
         "Document",
-        "Export",
+        "EXPORT",
         "FolderRoot",
-        "Inbox",
+        "INBOX",
         "MyStyle",
         "Note",
-        "Screenshot",
+        "SCREENSHOT",
     ]
 
 
@@ -122,9 +122,9 @@ async def test_list_query_returns_default_folders(
     ]
 
     # Verify all six visible folders are present in flattened view
-    assert "Export" in folders
-    assert "Inbox" in folders
-    assert "Screenshot" in folders
+    assert "EXPORT" in folders
+    assert "INBOX" in folders
+    assert "SCREENSHOT" in folders
     assert "Note" in folders
     assert "Document" in folders
     assert "MyStyle" in folders
@@ -134,7 +134,7 @@ async def test_list_query_returns_default_folders(
     assert "DOCUMENT" not in folders
 
     # Verify each default folder has correct properties
-    for folder_name in ["Export", "Inbox", "Screenshot", "Note", "Document", "MyStyle"]:
+    for folder_name in ["EXPORT", "INBOX", "SCREENSHOT", "Note", "Document", "MyStyle"]:
         folder_vo = next(f for f in res.user_file_vo_list if f.file_name == folder_name)
         assert folder_vo.is_folder == BooleanEnum.YES
         assert folder_vo.id is not None
@@ -354,7 +354,7 @@ async def test_path_query_flattening(
 async def test_system_dir_name_not_applied_to_user_folders(
     web_client: WebClient,
 ) -> None:
-    """Verify that system display names (e.g. 'Export') are not applied to user-created
+    """Verify that system folder names are not applied to user-created
     folders that happen to share a name with a system directory."""
     parent = await web_client.create_folder(parent_id=0, name="MyParent")
     parent_id = int(parent.id)
@@ -386,9 +386,9 @@ async def test_list_query_flattening(
     ]
 
     # Verify all categorized folders are at root level
-    assert "Export" in folder_names
-    assert "Inbox" in folder_names
-    assert "Screenshot" in folder_names
+    assert "EXPORT" in folder_names
+    assert "INBOX" in folder_names
+    assert "SCREENSHOT" in folder_names
     assert "Note" in folder_names
     assert "Document" in folder_names
     assert "MyStyle" in folder_names

--- a/tests/server/web/test_web_parity.py
+++ b/tests/server/web/test_web_parity.py
@@ -15,12 +15,12 @@ async def test_web_rename(web_client: WebClient) -> None:
     # Verify name change
     list_res = await web_client.list_query(directory_id=0)
     assert [f.file_name for f in list_res.user_file_vo_list] == [
-        "Screenshot",
+        "SCREENSHOT",
         "Note",
         "NewName",  # New folder
         "MyStyle",
-        "Inbox",
-        "Export",
+        "INBOX",
+        "EXPORT",
         "Document",
     ]
 
@@ -95,13 +95,13 @@ async def test_web_folder_list_query_spec(web_client: WebClient) -> None:
 
     # Check for presence and capitalization
     names = [f.file_name for f in folders]
-    assert names == ["Note", "Document", "Export", "Inbox", "MyStyle", "Screenshot"]
+    assert names == ["Note", "Document", "EXPORT", "INBOX", "MyStyle", "SCREENSHOT"]
 
     # Exclusion Filter (idList)
     note_id = int(next(f for f in folders if f.file_name == "Note").id)
     res_excl = await web_client.folder_list_query(directory_id=0, id_list=[note_id])
     names_excl = [f.file_name for f in res_excl.folder_vo_list]
-    assert names_excl == ["Document", "Export", "Inbox", "MyStyle", "Screenshot"]
+    assert names_excl == ["Document", "EXPORT", "INBOX", "MyStyle", "SCREENSHOT"]
 
     # Self-Exclusion (Folder hidden when in id_list)
     # Create a folder
@@ -118,10 +118,10 @@ async def test_web_folder_list_query_spec(web_client: WebClient) -> None:
     assert names_self_excl == [
         "Note",
         "Document",
-        "Export",
-        "Inbox",
+        "EXPORT",
+        "INBOX",
         "MyStyle",
-        "Screenshot",
+        "SCREENSHOT",
     ]
 
     # isEmpty Lookahead (sub-folders only)


### PR DESCRIPTION
## Summary

- Removes the `SYSTEM_DIR_DISPLAY_NAMES` mapping that was overriding stored folder names to title-case in the web UI (e.g. `EXPORT` → `Export`)
- System folders now display their actual stored names (`EXPORT`, `INBOX`, `SCREENSHOT`) in the web UI, matching what is stored on device
- Fixes a latent bug where `WEB_IMMUTABLE_NAMES` contained display names (`"Export"`) instead of raw DB names (`"EXPORT"`), causing immutability checks (delete/move/rename/copy protection) to silently fail for these folders

## Test plan

- [ ] All 400 existing tests pass
- [ ] Create a folder at root — verify `EXPORT`, `INBOX`, `SCREENSHOT` appear with all-caps names in the UI
- [ ] Attempt to delete/rename/move `EXPORT`, `INBOX`, or `SCREENSHOT` — should be blocked as immutable