### PR TITLE
fix: implement Engine.IO v3 WebSocket stub to resolve sync failures

### DIFF
--- a/supernote/server/routes/system.py
+++ b/supernote/server/routes/system.py
@@ -3,7 +3,6 @@ import json
 import logging
 import secrets
 
-import aiohttp
 from aiohttp import web
 
 from supernote.models.base import BaseResponse
@@ -88,11 +87,8 @@ async def handle_socketio(request: web.Request) -> web.WebSocketResponse:
 
     ping_task = asyncio.create_task(_ping_loop())
     try:
-        async for msg in ws:
-            if msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSE):
-                break
-    except Exception as exc:
-        logger.debug("socket.io connection error for sid=%s: %s", sid, exc)
+        async for _msg in ws:
+            pass
     finally:
         ping_task.cancel()
         try:

--- a/tests/server/routes/test_system.py
+++ b/tests/server/routes/test_system.py
@@ -82,3 +82,44 @@ async def test_health_endpoint(client: TestClient) -> None:
     assert resp.status == aiohttp.web.HTTPOk.status_code
     text = await resp.text()
     assert "Supernote" in text
+
+
+@pytest.mark.asyncio
+async def test_base_param_returns_server_config(client: TestClient) -> None:
+    """Device reads server limits and allowed file types."""
+    resp = await client.post("/api/official/system/base/param")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["success"] is True
+    params = {p["name"]: p["value"] for p in data["paramList"]}
+    assert "MAX_ERR_COUNTS" in params
+    assert "FILE_MAX" in params
+    assert "FILE_TYPE" in params
+    assert "note" in params["FILE_TYPE"]
+
+
+@pytest.mark.asyncio
+async def test_query_server_returns_success(client: TestClient) -> None:
+    """Device uses this endpoint to confirm it is talking to a Supernote server."""
+    resp = await client.get("/api/file/query/server")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_csrf_returns_token_header(client: TestClient) -> None:
+    """CSRF endpoint returns a token in the X-XSRF-TOKEN response header."""
+    resp = await client.get("/api/csrf")
+    assert resp.status == 200
+    token = resp.headers.get("X-XSRF-TOKEN")
+    assert token is not None
+    assert len(token) > 0
+
+
+@pytest.mark.asyncio
+async def test_csrf_tokens_are_unique(client: TestClient) -> None:
+    """Each call to /api/csrf returns a different token."""
+    resp1 = await client.get("/api/csrf")
+    resp2 = await client.get("/api/csrf")
+    assert resp1.headers["X-XSRF-TOKEN"] != resp2.headers["X-XSRF-TOKEN"]


### PR DESCRIPTION
## Summary

- Devices intermittently show "App Data Sync Failed" / "Private Cloud Sync Failed" because the `/socket.io/` endpoint returned 404, which the device treats as a hard failure rather than gracefully falling back
- The file sync itself succeeds (all API calls return 200), but the device retries the socket.io connection every 5 seconds and surfaces the failure to the user
- Replaces the 404 stub with a proper Engine.IO v3 WebSocket handler that accepts connections, sends the protocol handshake (`OPEN` + Socket.IO namespace connect), and maintains ping/pong keepalive

No push notifications are implemented — the connection is kept alive as a no-op, which is sufficient to prevent the device from reporting a sync failure.

## Test plan

- [ ] Connect a Supernote device to the server and verify "App Data Sync" and "Private Cloud Sync" no longer show failure errors
- [ ] Confirm server logs show WebSocket connections establishing (no more repeated 404s on `/socket.io/`)
- [ ] Verify file sync still works correctly (upload/download of notes)