### PR TITLE
fix: restore navigation state on refresh

### DIFF
--- a/supernote/server/static/index.html
+++ b/supernote/server/static/index.html
@@ -167,7 +167,7 @@
 
                 <!-- Viewer -->
                 <div v-if="view === 'viewer'" class="min-h-full">
-                    <file-viewer :file="selectedFile" @close="view = 'grid'"></file-viewer>
+                    <file-viewer :file="selectedFile" @close="closeViewer"></file-viewer>
                 </div>
 
                 <!-- Modals -->
@@ -191,7 +191,7 @@
         </main>
     </div>
     <!-- Load Main Module -->
-    <script type="module" src="/static/js/main.js"></script>
+    <script type="module" src="/static/js/main.js?v=2"></script>
 </body>
 
 </html>

--- a/supernote/server/static/js/main.js
+++ b/supernote/server/static/js/main.js
@@ -111,11 +111,18 @@ createApp({
         async function navigateTo(index) {
             const crumbs = breadcrumbs.value.slice(0, index + 1);
             breadcrumbs.value = crumbs;
+            view.value = 'grid';
+            selectedFile.value = null;
+            selectedIds.value = [];
             saveNavToUrl();
             const target = crumbs[crumbs.length - 1];
-            view.value = 'grid';
-            selectedIds.value = [];
             await loadDirectory(target.id);
+        }
+
+        function closeViewer() {
+            view.value = 'grid';
+            selectedFile.value = null;
+            saveNavToUrl();
         }
 
         // Selection
@@ -286,6 +293,7 @@ createApp({
             breadcrumbs,
             openItem,
             navigateTo,
+            closeViewer,
             selectedFile,
             showSystemPanel,
             showApiKeysPanel,


### PR DESCRIPTION
## Summary

Persists the current folder/note path in the URL so that refreshing the page or sharing a link restores the exact view.

- Navigating folders updates the URL: `/Note`, `/Note/SubFolder`
- Opening a note updates the URL: `/Note/myfile.note`
- Refreshing restores the full navigation state by walking the path
- Closing a note (via breadcrumb or close button) correctly removes the file from the URL
- Root (Cloud) is the default and is omitted from the URL

**Backend:** adds a SPA catch-all route that serves `index.html` for unknown paths, with explicit proxy handlers for MCP OAuth routes (`/.well-known/`, `/authorize`, `/token`, `/register`, `/login-bridge`) to avoid routing conflicts with the ASGI resource.

## Bug fixes included

- `navigateTo` was calling `saveNavToUrl()` before resetting `view`/`selectedFile`, leaving the file name in the URL when navigating back to a folder
- Viewer close button was using `@close="view = 'grid'"` inline, bypassing URL update — now calls `closeViewer()`

## Test plan

- [ ] Navigate into a folder — URL updates to `/FolderName`
- [ ] Open a note — URL updates to `/FolderName/note.note`
- [ ] Refresh while viewing a note — reopens the same note
- [ ] Refresh while in a folder — stays in that folder
- [ ] Close note via X button — URL reverts to folder path
- [ ] Close note via breadcrumb — URL reverts to folder path
- [ ] Copy URL of an open note and open in new tab — navigates directly to the note
- [ ] OAuth/MCP flow still works correctly