### PR TITLE
fix: improve toast notifications for file operations

### DIFF
--- a/supernote/server/static/index.html
+++ b/supernote/server/static/index.html
@@ -163,14 +163,6 @@
                     </div>
                 </div>
 
-                <!-- Error State -->
-                <div v-if="error" class="bg-gray-100 dark:bg-gray-800 text-black dark:text-white border border-gray-300 dark:border-gray-600 p-4 rounded mb-6">
-                    {{ error }}
-                    <div v-if="error === 'Unauthorized'" class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                        Please log in via the CLI or check your token.
-                    </div>
-                </div>
-
                 <!-- Loading State -->
                 <div v-if="isLoading" class="flex justify-center py-20">
                     <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-black dark:border-white"></div>

--- a/supernote/server/static/js/api/client.js
+++ b/supernote/server/static/js/api/client.js
@@ -112,7 +112,7 @@ export async function fetchFiles(directoryId = "0", pageNo = 1, pageSize = 50) {
             }
             throw new Error("Unauthorized");
         }
-        throw new Error(`Failed to fetch files: ${response.statusText}`);
+        throw new Error(`Failed to fetch files: ${response.status}`);
     }
 
     const data = await response.json();
@@ -159,7 +159,7 @@ export async function convertNoteToPng(fileId) {
             logout();
             throw new Error("Unauthorized");
         }
-        throw new Error(`Conversion failed: ${response.statusText}`);
+        throw new Error(`Conversion failed: ${response.status}`);
     }
 
     const data = await response.json();
@@ -190,7 +190,7 @@ export async function fetchSummaries(fileId) {
             logout();
             throw new Error("Unauthorized");
         }
-        throw new Error(`Summary fetch failed: ${response.statusText}`);
+        throw new Error(`Summary fetch failed: ${response.status}`);
     }
 
     const data = await response.json();
@@ -219,7 +219,7 @@ export async function fetchSystemTasks() {
     }
 
     if (!response.ok) {
-        throw new Error(`Failed to fetch system tasks: ${response.statusText}`);
+        throw new Error(`Failed to fetch system tasks: ${response.status}`);
     }
 
     return await response.json();
@@ -248,7 +248,7 @@ export async function fetchCapacity() {
     }
 
     if (!response.ok) {
-        throw new Error(`Failed to fetch capacity: ${response.statusText}`);
+        throw new Error(`Failed to fetch capacity: ${response.status}`);
     }
 
     return await response.json();
@@ -274,7 +274,7 @@ export async function createFolder(directoryId, folderName) {
     });
 
     if (!response.ok) {
-        throw new Error(`Failed to create folder: ${response.statusText}`);
+        throw new Error(`Failed to create folder: ${response.status}`);
     }
 
     return await response.json();
@@ -300,7 +300,7 @@ export async function deleteItems(directoryId, idList) {
     });
 
     if (!response.ok) {
-        throw new Error(`Failed to delete items: ${response.statusText}`);
+        throw new Error(`Failed to delete items: ${response.status}`);
     }
 
     return await response.json();
@@ -327,7 +327,7 @@ export async function moveItems(idList, targetDirectoryId) {
     });
 
     if (!response.ok) {
-        throw new Error(`Failed to move items: ${response.statusText}`);
+        throw new Error(`Failed to move items: ${response.status}`);
     }
 
     return await response.json();
@@ -353,7 +353,7 @@ export async function renameItem(id, newName) {
     });
 
     if (!response.ok) {
-        throw new Error(`Failed to rename item: ${response.statusText}`);
+        throw new Error(`Failed to rename item: ${response.status}`);
     }
 
     return await response.json();
@@ -381,7 +381,7 @@ async function uploadApply(directoryId, fileName, size, md5) {
     });
 
     if (!response.ok) {
-        throw new Error(`Upload apply failed: ${response.statusText}`);
+        throw new Error(`Upload apply failed: ${response.status}`);
     }
 
     return await response.json();
@@ -411,7 +411,7 @@ async function uploadFinish(directoryId, fileName, size, md5, innerName) {
     });
 
     if (!response.ok) {
-        throw new Error(`Upload finish failed: ${response.statusText}`);
+        throw new Error(`Upload finish failed: ${response.status}`);
     }
 
     return await response.json();
@@ -440,7 +440,7 @@ export async function uploadFile(directoryId, file, onProgress) {
     });
 
     if (!uploadResp.ok) {
-        throw new Error(`File binary upload failed: ${uploadResp.statusText}`);
+        throw new Error(`File binary upload failed: ${uploadResp.status}`);
     }
 
     // 4. Finish
@@ -474,7 +474,7 @@ export async function fetchApiKeys() {
     });
 
     if (response.status === 401) { logout(); throw new Error("Unauthorized"); }
-    if (!response.ok) throw new Error(`Failed to fetch API keys: ${response.statusText}`);
+    if (!response.ok) throw new Error(`Failed to fetch API keys: ${response.status}`);
     return await response.json();
 }
 
@@ -489,7 +489,7 @@ export async function createApiKey(name) {
     });
 
     if (response.status === 401) { logout(); throw new Error("Unauthorized"); }
-    if (!response.ok) throw new Error(`Failed to create API key: ${response.statusText}`);
+    if (!response.ok) throw new Error(`Failed to create API key: ${response.status}`);
     return await response.json();
 }
 
@@ -503,7 +503,7 @@ export async function deleteApiKey(keyId) {
     });
 
     if (response.status === 401) { logout(); throw new Error("Unauthorized"); }
-    if (!response.ok) throw new Error(`Failed to delete API key: ${response.statusText}`);
+    if (!response.ok) throw new Error(`Failed to delete API key: ${response.status}`);
 }
 
 /**
@@ -519,7 +519,7 @@ export async function fetchOAuthSessions() {
     });
 
     if (response.status === 401) { logout(); throw new Error("Unauthorized"); }
-    if (!response.ok) throw new Error(`Failed to fetch sessions: ${response.statusText}`);
+    if (!response.ok) throw new Error(`Failed to fetch sessions: ${response.status}`);
     return await response.json();
 }
 
@@ -533,7 +533,7 @@ export async function deleteOAuthSession(sessionId) {
     });
 
     if (response.status === 401) { logout(); throw new Error("Unauthorized"); }
-    if (!response.ok) throw new Error(`Failed to revoke session: ${response.statusText}`);
+    if (!response.ok) throw new Error(`Failed to revoke session: ${response.status}`);
 }
 
 /**
@@ -560,7 +560,7 @@ export async function fetchProcessingStatus(fileIds) {
     }
 
     if (!response.ok) {
-        throw new Error(`Failed to fetch processing status: ${response.statusText}`);
+        throw new Error(`Failed to fetch processing status: ${response.status}`);
     }
 
     const data = await response.json();

--- a/supernote/server/static/js/main.js
+++ b/supernote/server/static/js/main.js
@@ -162,7 +162,7 @@ createApp({
                 showNewFolderModal.value = false;
                 newFolderName.value = '';
             } catch (e) {
-                addToast('Failed to create folder', e.message);
+                addToast(`Failed to create folder "${newFolderName.value}"`, e.message);
             }
         }
 
@@ -177,7 +177,8 @@ createApp({
             try {
                 await uploadFiles(selectedFiles);
             } catch (e) {
-                addToast('Upload failed', e.message);
+                const names = Array.from(selectedFiles).map(f => f.name).join(', ');
+                addToast(`Upload failed: ${names}`, e.message);
             } finally {
                 event.target.value = ''; // Reset input
             }
@@ -189,7 +190,8 @@ createApp({
                 await deleteSelectedItems(selectedIds.value);
                 selectedIds.value = [];
             } catch (e) {
-                addToast('Delete failed', e.message);
+                const names = files.value.filter(f => selectedIds.value.includes(f.id)).map(f => f.name).join(', ');
+                addToast(`Delete failed: ${names}`, e.message);
             }
         }
 
@@ -203,7 +205,8 @@ createApp({
                 selectedIds.value = [];
                 showMoveModal.value = false;
             } catch (e) {
-                addToast('Move failed', e.message);
+                const names = files.value.filter(f => selectedIds.value.includes(f.id)).map(f => f.name).join(', ');
+                addToast(`Move failed: ${names}`, e.message);
             }
         }
 
@@ -218,7 +221,7 @@ createApp({
                 showRenameModal.value = false;
                 itemToRename.value = null;
             } catch (e) {
-                addToast('Rename failed', e.message);
+                addToast(`Rename failed: "${itemToRename.value.name}" → "${newName}"`, e.message);
             }
         }
 


### PR DESCRIPTION
## Summary

- Remove the inline error state div below the action bar — toasts already handle error feedback
- Replace `response.statusText` with `response.status` across all API calls (statusText is empty in HTTP/2, causing error messages to end with just `:`)
- Include relevant item names in all error toasts for create folder, upload, delete, move, and rename operations

## Test plan

- [ ] Trigger a failed rename and verify the toast shows `Rename failed: "old name" → "new name"` with a valid HTTP status code in the detail
- [ ] Trigger a failed delete and verify the toast shows the selected item names
- [ ] Trigger a failed move and verify the toast shows the selected item names
- [ ] Trigger a failed upload and verify the toast shows the file name(s)
- [ ] Confirm the inline error block no longer appears below the Upload/New Folder buttons