### PR TITLE
fix(security): add usedforsecurity=False to all hashlib.md5 calls

### DIFF
--- a/supernote/cli/admin.py
+++ b/supernote/cli/admin.py
@@ -36,9 +36,7 @@ async def add_user_async(
 
         # Hash password
         _warn_md5_usage()
-        password_md5 = hashlib.md5(
-            password.encode(), usedforsecurity=False
-        ).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
+        password_md5 = hashlib.md5(password.encode(), usedforsecurity=False).hexdigest()
 
         # Try Public Registration
         try:
@@ -125,9 +123,7 @@ async def reset_password_async(url: str, email: str, password: str) -> None:
         admin_client = AdminClient(session.client)
 
         _warn_md5_usage()
-        password_md5 = hashlib.md5(
-            password.encode(), usedforsecurity=False
-        ).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
+        password_md5 = hashlib.md5(password.encode(), usedforsecurity=False).hexdigest()
 
         try:
             await admin_client.admin_reset_password(email, password_md5)

--- a/supernote/cli/admin.py
+++ b/supernote/cli/admin.py
@@ -36,7 +36,7 @@ async def add_user_async(
 
         # Hash password
         _warn_md5_usage()
-        password_md5 = hashlib.md5(password.encode()).hexdigest()
+        password_md5 = hashlib.md5(password.encode(), usedforsecurity=False).hexdigest()
 
         # Try Public Registration
         try:
@@ -123,7 +123,7 @@ async def reset_password_async(url: str, email: str, password: str) -> None:
         admin_client = AdminClient(session.client)
 
         _warn_md5_usage()
-        password_md5 = hashlib.md5(password.encode()).hexdigest()
+        password_md5 = hashlib.md5(password.encode(), usedforsecurity=False).hexdigest()
 
         try:
             await admin_client.admin_reset_password(email, password_md5)

--- a/supernote/cli/admin.py
+++ b/supernote/cli/admin.py
@@ -36,7 +36,9 @@ async def add_user_async(
 
         # Hash password
         _warn_md5_usage()
-        password_md5 = hashlib.md5(password.encode(), usedforsecurity=False).hexdigest()
+        password_md5 = hashlib.md5(
+            password.encode(), usedforsecurity=False
+        ).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
 
         # Try Public Registration
         try:
@@ -123,7 +125,9 @@ async def reset_password_async(url: str, email: str, password: str) -> None:
         admin_client = AdminClient(session.client)
 
         _warn_md5_usage()
-        password_md5 = hashlib.md5(password.encode(), usedforsecurity=False).hexdigest()
+        password_md5 = hashlib.md5(
+            password.encode(), usedforsecurity=False
+        ).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
 
         try:
             await admin_client.admin_reset_password(email, password_md5)

--- a/supernote/client/client.py
+++ b/supernote/client/client.py
@@ -281,7 +281,7 @@ class Client:
                 raise ValueError("No upload URL available")
 
             # Compute MD5 of content for verification
-            content_md5 = hashlib.md5(content).hexdigest()
+            content_md5 = hashlib.md5(content, usedforsecurity=False).hexdigest()
 
             _LOGGER.debug(
                 "Uploading file %s in one chunk (MD5: %s)", filename, content_md5
@@ -324,7 +324,7 @@ class Client:
         # Break into chunks
         chunks = [content[i : i + chunk_size] for i in range(0, size, chunk_size)]
         for i, chunk in enumerate(chunks):
-            chunk_md5 = hashlib.md5(chunk).hexdigest()
+            chunk_md5 = hashlib.md5(chunk, usedforsecurity=False).hexdigest()
             _LOGGER.debug(f"Uploading chunk {i + 1} of {size} ({len(chunk)} bytes)")
             data = FormData()
             data.add_field("file", chunk, filename=filename)

--- a/supernote/client/device.py
+++ b/supernote/client/device.py
@@ -173,7 +173,7 @@ class DeviceClient:
         _LOGGER.debug("Initiating upload for file %s", path)
         apply = await self.upload_apply(filename, path, size, equipment_no)
 
-        md5 = hashlib.md5(content).hexdigest()
+        md5 = hashlib.md5(content, usedforsecurity=False).hexdigest()
 
         await self._client._upload_to_oss(
             content,

--- a/supernote/client/hashing.py
+++ b/supernote/client/hashing.py
@@ -35,7 +35,7 @@ def _md5_string(s: str) -> str:
     Security Warning: MD5 is cryptographically broken but required for Supernote protocol compatibility.
     """
     _warn_md5_usage()
-    return hashlib.md5(s.encode("utf-8")).hexdigest()
+    return hashlib.md5(s.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 def hash_with_salt(content: str, salt: str) -> str:

--- a/supernote/client/hashing.py
+++ b/supernote/client/hashing.py
@@ -35,7 +35,9 @@ def _md5_string(s: str) -> str:
     Security Warning: MD5 is cryptographically broken but required for Supernote protocol compatibility.
     """
     _warn_md5_usage()
-    return hashlib.md5(s.encode("utf-8"), usedforsecurity=False).hexdigest()
+    return hashlib.md5(
+        s.encode("utf-8"), usedforsecurity=False
+    ).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
 
 
 def hash_with_salt(content: str, salt: str) -> str:

--- a/supernote/client/hashing.py
+++ b/supernote/client/hashing.py
@@ -35,9 +35,7 @@ def _md5_string(s: str) -> str:
     Security Warning: MD5 is cryptographically broken but required for Supernote protocol compatibility.
     """
     _warn_md5_usage()
-    return hashlib.md5(
-        s.encode("utf-8"), usedforsecurity=False
-    ).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
+    return hashlib.md5(s.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 def hash_with_salt(content: str, salt: str) -> str:

--- a/supernote/client/web.py
+++ b/supernote/client/web.py
@@ -177,7 +177,7 @@ class WebClient:
 
     async def upload_file(self, parent_id: int, name: str, content: bytes) -> None:
         """Upload a file (Web API)."""
-        md5 = hashlib.md5(content).hexdigest()
+        md5 = hashlib.md5(content, usedforsecurity=False).hexdigest()
         size = len(content)
 
         # Apply to get an upload endpoint

--- a/supernote/server/services/blob.py
+++ b/supernote/server/services/blob.py
@@ -106,7 +106,7 @@ class LocalBlobStorage(BlobStorage):
         temp_path = temp_dir / f"{secrets.token_hex(8)}.tmp"
 
         total_size = 0
-        md5_hasher = hashlib.md5()
+        md5_hasher = hashlib.md5(usedforsecurity=False)
 
         try:
             async with aiofiles.open(temp_path, "wb") as f:
@@ -191,7 +191,7 @@ class LocalBlobStorage(BlobStorage):
             return BlobMetadata(size=stat.st_size)
 
         # Compute MD5 and size
-        md5_hasher = hashlib.md5()
+        md5_hasher = hashlib.md5(usedforsecurity=False)
         read_size = 0
         async with aiofiles.open(path, "rb") as f:
             while True:

--- a/uv.lock
+++ b/uv.lock
@@ -1447,7 +1447,7 @@ wheels = [
 
 [[package]]
 name = "supernote"
-version = "1.6.4"
+version = "1.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "colour" },


### PR DESCRIPTION
## Summary

- Adds `usedforsecurity=False` to all 9 `hashlib.md5()` calls across `client/`, `cli/`, and `server/`
- MD5 is mandated by the Supernote protocol and cannot be replaced — the flag explicitly documents this intent
- Resolves all 7 open CodeQL `py/use-of-broken-or-weak-cryptographic-algorithm` alerts in code scanning

## Details

All MD5 uses fall into two categories, both protocol-locked:
- **Password pre-hashing** (`cli/admin.py`, `client/hashing.py`): protocol scheme is `SHA256(MD5(password) + randomCode)`; device sends and expects MD5-prehashed passwords
- **File integrity checksums** (`client/client.py`, `client/web.py`, `client/device.py`, `server/services/blob.py`): `md5` field is a required field in upload API requests/responses; server returns it and device verifies it

`usedforsecurity=False` is the correct suppression mechanism: it signals to static analysis tools and FIPS-compliant OpenSSL that MD5 here is not a security primitive choice but a protocol compatibility requirement.

## Test plan

- [x] All existing tests pass (`29 passed`)
- [x] Lint clean (ruff, mypy, codespell)